### PR TITLE
Added custom blueprint getter/setter nodes with an explicit ViewModel input pin

### DIFF
--- a/UnrealMvvm/Source/UnrealMvvm/Public/Mvvm/MvvmBlueprintLibrary.h
+++ b/UnrealMvvm/Source/UnrealMvvm/Public/Mvvm/MvvmBlueprintLibrary.h
@@ -55,6 +55,12 @@ private:
     friend class UK2Node_ViewModelGetSet;
 
     UFUNCTION(BlueprintPure, CustomThunk, meta = (CustomStructureParam = "Value", BlueprintInternalUseOnly = "true"))
+    static void GetViewModelPropertyValue(UBaseViewModel* ViewModel, FName PropertyName, int32& Value, bool& HasValue)
+    {
+        checkNoEntry();
+    }
+    
+    UFUNCTION(BlueprintPure, CustomThunk, meta = (CustomStructureParam = "Value", BlueprintInternalUseOnly = "true"))
     static void GetViewModelPropertyValueFromWidget(UUserWidget* View, FName PropertyName, int32& Value, bool& HasValue)
     {
         checkNoEntry();
@@ -78,6 +84,12 @@ private:
         checkNoEntry();
     }
 
+    UFUNCTION(BlueprintCallable, CustomThunk, meta = (CustomStructureParam = "Value", BlueprintInternalUseOnly = "true"))
+    static void SetViewModelPropertyValue(UBaseViewModel* ViewModel, FName PropertyName, int32 Value, bool HasValue)
+    {
+        checkNoEntry();
+    }
+
     UFUNCTION(BlueprintPure, Category = "ViewModel", meta = (BlueprintInternalUseOnly = "true"))
     static UBaseViewModel* GetViewModelFromWidget(UUserWidget* View);
 
@@ -90,10 +102,12 @@ private:
     UFUNCTION(BlueprintCallable, Category = "ViewModel", meta = (BlueprintInternalUseOnly = "true"))
     static void SetViewModelToActor(AActor* View, UBaseViewModel* ViewModel);
 
+    DECLARE_FUNCTION(execGetViewModelPropertyValue);
     DECLARE_FUNCTION(execGetViewModelPropertyValueFromWidget);
     DECLARE_FUNCTION(execSetViewModelPropertyValueToWidget);
     DECLARE_FUNCTION(execGetViewModelPropertyValueFromActor);
     DECLARE_FUNCTION(execSetViewModelPropertyValueToActor);
+    DECLARE_FUNCTION(execSetViewModelPropertyValue);
 
     template <typename TView, typename TViewComponent>
     static UBaseViewModel* GetViewModelInternal(TView* View);
@@ -105,6 +119,9 @@ private:
     DECLARE_FUNCTION(execGetViewModelPropertyValueInternal);
 
     template<typename TView>
+    DECLARE_FUNCTION(execSetViewModelPropertyValueInternal);
+
+    DECLARE_FUNCTION(execGetViewModelPropertyValueInternal);
     DECLARE_FUNCTION(execSetViewModelPropertyValueInternal);
 
     template <typename TView>

--- a/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitGetViewModelPropertyValue.cpp
+++ b/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitGetViewModelPropertyValue.cpp
@@ -1,0 +1,49 @@
+// Copyright Andrei Sudarikov. All Rights Reserved.
+
+#include "K2Node_ExplicitGetViewModelPropertyValue.h"
+#include "ViewModelPropertyNodeHelper.h"
+#include "Kismet2/CompilerResultsLog.h"
+
+void UK2Node_ExplicitGetViewModelPropertyValue::ExpandNode(FKismetCompilerContext& CompilerContext, UEdGraph* SourceGraph)
+{
+    if (FindPin(ViewModelPropertyName)->LinkedTo.Num() > 0)
+    {
+        FViewModelPropertyNodeHelper::SpawnExplicitGetSetPropertyValueNodes(FViewModelPropertyNodeHelper::GetFunctionNameForGetPropertyValue(), CompilerContext, this, SourceGraph, ViewModelPropertyName);
+    }
+}
+
+FText UK2Node_ExplicitGetViewModelPropertyValue::GetNodeTitle(ENodeTitleType::Type TitleType) const
+{
+    FText Title = Super::GetNodeTitle(TitleType);
+    if (TitleType == ENodeTitleType::MenuTitle || TitleType == ENodeTitleType::ListView)
+    {
+        Title = FText::Format(NSLOCTEXT("UnrealMvvm", "ExplicitGetViewModelPropertyValue_Title", "{0} (explicit)"), Title);
+    }
+    return Title;
+}
+
+bool UK2Node_ExplicitGetViewModelPropertyValue::IsActionFilteredOut(FBlueprintActionFilter const& Filter)
+{
+    return !FViewModelPropertyNodeHelper::IsActionValidInContext(Filter, ViewModelOwnerClass);
+}
+
+void UK2Node_ExplicitGetViewModelPropertyValue::AllocateDefaultPins()
+{
+    Super::AllocateDefaultPins();
+
+    FViewModelPropertyNodeHelper::AddInputViewModelPin(*this, ViewModelOwnerClass);
+}
+
+void UK2Node_ExplicitGetViewModelPropertyValue::ValidateNodeDuringCompilation(FCompilerResultsLog& MessageLog) const
+{
+    Super::ValidateNodeDuringCompilation(MessageLog);
+
+    FViewModelPropertyNodeHelper::ValidateInputViewModelPin(this, MessageLog);
+}
+
+FText UK2Node_ExplicitGetViewModelPropertyValue::GetNodeTitleForCache(ENodeTitleType::Type TitleType) const
+{
+    return TitleType == ENodeTitleType::FullTitle
+        ? FText::Format(NSLOCTEXT("UnrealMvvm", "ExplicitGetViewModelPropertyValue_TitleFull", "Get {0}\nFrom {1}"), FText::FromName(ViewModelPropertyName), GetViewModelDisplayName())
+        : FText::Format(NSLOCTEXT("UnrealMvvm", "ExplicitGetViewModelPropertyValue_Title", "Get {0}"), FText::FromName(ViewModelPropertyName));
+}

--- a/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitGetViewModelPropertyValue.h
+++ b/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitGetViewModelPropertyValue.h
@@ -1,0 +1,32 @@
+// Copyright Andrei Sudarikov. All Rights Reserved.
+
+#pragma once
+
+#include "K2Node_GetViewModelPropertyValue.h"
+#include "K2Node_ExplicitGetViewModelPropertyValue.generated.h"
+
+/*
+ * Custom node that returns value of a ViewModel property.
+ * Unlike its parent node, explicitly accepts a ViewModel of required type as an input pin.
+ * This node registers custom Menu actions for all properties of a ViewModel.
+ */
+UCLASS()
+class UK2Node_ExplicitGetViewModelPropertyValue : public UK2Node_GetViewModelPropertyValue
+{
+    GENERATED_BODY()
+
+public:
+    //~ Begin UK2Node Interface
+    void ExpandNode(FKismetCompilerContext& CompilerContext, UEdGraph* SourceGraph) override;
+    FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
+    bool IsActionFilteredOut(class FBlueprintActionFilter const& Filter) override;
+    //~ End UK2Node Interface
+
+    //~ Begin UEdGraphNode Interface
+    void AllocateDefaultPins() override;
+    void ValidateNodeDuringCompilation(FCompilerResultsLog& MessageLog) const override;
+    //~ End UEdGraphNode Interface
+
+protected:
+    FText GetNodeTitleForCache(ENodeTitleType::Type TitleType) const override;
+};

--- a/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitSetViewModelPropertyValue.cpp
+++ b/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitSetViewModelPropertyValue.cpp
@@ -1,0 +1,46 @@
+// Copyright Andrei Sudarikov. All Rights Reserved.
+
+#include "K2Node_ExplicitSetViewModelPropertyValue.h"
+#include "ViewModelPropertyNodeHelper.h"
+#include "Kismet2/CompilerResultsLog.h"
+
+void UK2Node_ExplicitSetViewModelPropertyValue::ExpandNode(FKismetCompilerContext& CompilerContext, UEdGraph* SourceGraph)
+{
+    FViewModelPropertyNodeHelper::SpawnExplicitGetSetPropertyValueNodes(FViewModelPropertyNodeHelper::GetFunctionNameForSetPropertyValue(), CompilerContext, this, SourceGraph, ViewModelPropertyName);
+}
+
+FText UK2Node_ExplicitSetViewModelPropertyValue::GetNodeTitle(ENodeTitleType::Type TitleType) const
+{
+    FText Title = Super::GetNodeTitle(TitleType);
+    if (TitleType == ENodeTitleType::MenuTitle || TitleType == ENodeTitleType::ListView)
+    {
+        Title = FText::Format(NSLOCTEXT("UnrealMvvm", "ExplicitSetViewModelPropertyValue_Title", "{0} (explicit)"), Title);
+    }
+    return Title;
+}
+
+bool UK2Node_ExplicitSetViewModelPropertyValue::IsActionFilteredOut(FBlueprintActionFilter const& Filter)
+{
+    return !FViewModelPropertyNodeHelper::IsActionValidInContext(Filter, ViewModelOwnerClass);
+}
+
+void UK2Node_ExplicitSetViewModelPropertyValue::AllocateDefaultPins()
+{
+    Super::AllocateDefaultPins();
+
+    FViewModelPropertyNodeHelper::AddInputViewModelPin(*this, ViewModelOwnerClass);
+}
+
+void UK2Node_ExplicitSetViewModelPropertyValue::ValidateNodeDuringCompilation(FCompilerResultsLog& MessageLog) const
+{
+    Super::ValidateNodeDuringCompilation(MessageLog);
+
+    FViewModelPropertyNodeHelper::ValidateInputViewModelPin(this, MessageLog);
+}
+
+FText UK2Node_ExplicitSetViewModelPropertyValue::GetNodeTitleForCache(ENodeTitleType::Type TitleType) const
+{
+    return TitleType == ENodeTitleType::FullTitle
+        ? FText::Format(NSLOCTEXT("UnrealMvvm", "ExplicitSetViewModelPropertyValue_TitleFull", "Set {0}\nTo {1}"), FText::FromName(ViewModelPropertyName), GetViewModelDisplayName())
+        : FText::Format(NSLOCTEXT("UnrealMvvm", "ExplicitSetViewModelPropertyValue_Title", "Set {0}"), FText::FromName(ViewModelPropertyName));
+}

--- a/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitSetViewModelPropertyValue.h
+++ b/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/K2Node_ExplicitSetViewModelPropertyValue.h
@@ -1,0 +1,32 @@
+// Copyright Andrei Sudarikov. All Rights Reserved.
+
+#pragma once
+
+#include "K2Node_SetViewModelPropertyValue.h"
+#include "K2Node_ExplicitSetViewModelPropertyValue.generated.h"
+
+/*
+ * Custom node that sets value to a ViewModel property.
+ * Unlike its parent node, explicitly accepts a ViewModel of required type as an input pin.
+ * This node registers custom Menu actions for all properties of a ViewModel.
+ */
+UCLASS()
+class UK2Node_ExplicitSetViewModelPropertyValue : public UK2Node_SetViewModelPropertyValue
+{
+    GENERATED_BODY()
+
+public:
+    //~ Begin UK2Node Interface
+    void ExpandNode(FKismetCompilerContext& CompilerContext, UEdGraph* SourceGraph) override;
+    FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
+    bool IsActionFilteredOut(class FBlueprintActionFilter const& Filter) override;
+    //~ End UK2Node Interface
+
+    //~ Begin UEdGraphNode Interface
+    void AllocateDefaultPins() override;
+    void ValidateNodeDuringCompilation(FCompilerResultsLog& MessageLog) const;
+    //~ End UEdGraphNode Interface
+
+protected:
+    FText GetNodeTitleForCache(ENodeTitleType::Type TitleType) const override;
+};

--- a/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/ViewModelPropertyNodeHelper.h
+++ b/UnrealMvvm/Source/UnrealMvvmEditor/Private/Nodes/ViewModelPropertyNodeHelper.h
@@ -30,9 +30,28 @@ public:
     /* Spawns intermediate node equivalent to Self -> GetViewModelPropertyValue(View, ViewModelPropertyName) and connects its output to a given ValuePin */
     static void SpawnGetSetPropertyValueNodes(const FName& FunctionName, FKismetCompilerContext& CompilerContext, UEdGraphNode* SourceNode, UEdGraph* SourceGraph, const FName& ViewModelPropertyName);
 
+    /* Connects input ViewModel to GetViewModelPropertyValue(ViewModel, ViewModelPropertyName) and connects its output to a given ValuePin */
+    static void SpawnExplicitGetSetPropertyValueNodes(const FName& FunctionName, FKismetCompilerContext& CompilerContext, UEdGraphNode* SourceNode, UEdGraph* SourceGraph, const FName& ViewModelPropertyName);
+
+    /* Adds an input ViewModel pin to the getter/setter node. */
+    static void AddInputViewModelPin(UEdGraphNode& Node, UClass* ViewModelClass);
+
+    /* Returns true if an action for the given ViewModelOwnerClass is valid for current context represented by Filter and should be shown in actions menu. */
+    static bool IsActionValidInContext(const FBlueprintActionFilter& Filter, const UClass* ViewModelOwnerClass);
+
+    static void ValidateInputViewModelPin(const UEdGraphNode* Node, FCompilerResultsLog& MessageLog);
+
     static FName GetFunctionNameForGetPropertyValue(UClass* ViewClass);
     static FName GetFunctionNameForSetPropertyValue(UClass* ViewClass);
+    static FName GetFunctionNameForGetPropertyValue();
+    static FName GetFunctionNameForSetPropertyValue();
 
     /* Pin Name for HasValue */
     static const FName HasValuePinName;
+
+    /* Pin Name for input ViewModel */
+    static const FName InputViewModelPinName;
+
+private:
+    static void ConnectOutputPins(class UK2Node_CallFunction* GetSetFunctionNode, FKismetCompilerContext& CompilerContext, UEdGraphNode* SourceNode, UEdGraph* SourceGraph, const UEdGraphSchema_K2* Schema, UEdGraphPin* ValuePin, const FName& ViewModelPropertyName);
 };


### PR DESCRIPTION
Added new custom getter/setter nodes that take a ViewModel input pin.

This is needed to get/set property values on nested ViewModel properties of a widget/actor. Current get/set nodes assume that the ViewModel they operate on is always from 'self' context.